### PR TITLE
[LFND-87] Implement jwt authtentification, register and login endpoints

### DIFF
--- a/api/v1/endpoints/user.py
+++ b/api/v1/endpoints/user.py
@@ -11,8 +11,8 @@ router = APIRouter(prefix="/users", tags=["User"])
 
 @router.get("/me")
 async def get_current_user(db: DatabaseManager = Depends(get_database), token = Depends(JWTBearer())):
-    username = decodeJWT(token)
-    current_user = await db.get_user_by_username(username)
+    token_info = decodeJWT(token)
+    current_user = await db.get_user_by_username(token_info["user_id"])
     return current_user
 
 
@@ -27,8 +27,7 @@ async def login_for_access_token(
     db: DatabaseManager = Depends(get_database),
     form_data: OAuth2PasswordRequestForm = Depends(),
 ):
-    users = await db.get_users_list()
-    user = authenticate_user(users, form_data.username, form_data.password)
+    user = await authenticate_user(db, form_data.username, form_data.password)
     if not user:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/api/v1/endpoints/user.py
+++ b/api/v1/endpoints/user.py
@@ -10,7 +10,9 @@ router = APIRouter(prefix="/users", tags=["User"])
 
 
 @router.get("/me")
-async def get_current_user(db: DatabaseManager = Depends(get_database), token = Depends(JWTBearer())):
+async def get_current_user(
+    db: DatabaseManager = Depends(get_database), token=Depends(JWTBearer())
+):
     token_info = decodeJWT(token)
     current_user = await db.get_user_by_username(token_info["user_id"])
     return current_user
@@ -38,8 +40,11 @@ async def login_for_access_token(
     access_token = signJWT(user.username)
     return {"access_token": access_token, "token_type": "bearer"}
 
+
 @router.post("/signup")
-async def signup(db: DatabaseManager = Depends(get_database), user_info: UserBaseSchema = Body(...)):
+async def signup(
+    db: DatabaseManager = Depends(get_database), user_info: UserBaseSchema = Body(...)
+):
     user_info.password = get_password_hash(user_info.password)
     await db.create_user(user_info.dict())
     access_token = signJWT(user_info.username)

--- a/api/v1/endpoints/user.py
+++ b/api/v1/endpoints/user.py
@@ -1,27 +1,28 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Body, Depends, HTTPException, status
 from db import get_database, DatabaseManager
 from fastapi.security import OAuth2PasswordRequestForm
-from core.security import authenticate_user
-
+from core.security import authenticate_user, decodeJWT, get_password_hash
 
 from core.security import signJWT, JWTBearer
+from schemas.users_schema import UserSchema, UserBaseSchema
 
 router = APIRouter(prefix="/users", tags=["User"])
 
 
-@router.get("/me", dependencies=[Depends(JWTBearer())])
-async def get_me():
-    print("Aaaa")
-    return {"MES": "i"}
+@router.get("/me")
+async def get_current_user(db: DatabaseManager = Depends(get_database), token = Depends(JWTBearer())):
+    username = decodeJWT(token)
+    current_user = await db.get_user_by_username(username)
+    return current_user
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(JWTBearer())])
 async def get_users(db: DatabaseManager = Depends(get_database)):
     users = await db.get_users_list()
     return users
 
 
-@router.post("/token")
+@router.post("/login")
 async def login_for_access_token(
     db: DatabaseManager = Depends(get_database),
     form_data: OAuth2PasswordRequestForm = Depends(),
@@ -36,4 +37,11 @@ async def login_for_access_token(
         )
 
     access_token = signJWT(user.username)
+    return {"access_token": access_token, "token_type": "bearer"}
+
+@router.post("/signup")
+async def signup(db: DatabaseManager = Depends(get_database), user_info: UserBaseSchema = Body(...)):
+    user_info.password = get_password_hash(user_info.password)
+    await db.create_user(user_info.dict())
+    access_token = signJWT(user_info.username)
     return {"access_token": access_token, "token_type": "bearer"}

--- a/api/v1/endpoints/user.py
+++ b/api/v1/endpoints/user.py
@@ -1,12 +1,39 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from db import get_database, DatabaseManager
-import json
+from fastapi.security import OAuth2PasswordRequestForm
+from core.security import authenticate_user
 
+
+from core.security import signJWT, JWTBearer
 
 router = APIRouter(prefix="/users", tags=["User"])
+
+
+@router.get("/me", dependencies=[Depends(JWTBearer())])
+async def get_me():
+    print("Aaaa")
+    return {"MES": "i"}
 
 
 @router.get("/")
 async def get_users(db: DatabaseManager = Depends(get_database)):
     users = await db.get_users_list()
     return users
+
+
+@router.post("/token")
+async def login_for_access_token(
+    db: DatabaseManager = Depends(get_database),
+    form_data: OAuth2PasswordRequestForm = Depends(),
+):
+    users = await db.get_users_list()
+    user = authenticate_user(users, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    access_token = signJWT(user.username)
+    return {"access_token": access_token, "token_type": "bearer"}

--- a/core/config.py
+++ b/core/config.py
@@ -7,6 +7,9 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "Lohfinder"
     BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = ["http://localhost:8000"]
     MONGO_URL: str = "mongodb+srv://lohyna:4fKHPUizesfSsDrZ@lohfindercluster.u7ln4.mongodb.net/myFirstDatabase?retryWrites=true&w=majority"
+    SECRET_KEY: str = "7f1e5baaef44bf34e3584a90cfc81a09ced9998db45d7c17f72c19c82b255453"
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES = 24 * 60  # 24 hours
 
 
 settings = Settings()

--- a/core/security.py
+++ b/core/security.py
@@ -18,8 +18,8 @@ def verify_password(plain_password, hashed_password):
     return pwd_context.verify(plain_password, hashed_password)
 
 
-def authenticate_user(users, username: str, password: str):
-    user = next(i for i in users if i.username == username)
+async def authenticate_user(db, username: str, password: str):
+    user = await db.get_user_by_username(username)
     if not user:
         return False
     if not verify_password(password, user.password):

--- a/core/security.py
+++ b/core/security.py
@@ -1,0 +1,77 @@
+from jose import jwt
+from passlib.context import CryptContext
+from fastapi.security import OAuth2PasswordBearer
+from fastapi import HTTPException
+from core.config import settings
+from typing import Dict
+import time
+from fastapi import Request, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def authenticate_user(users, username: str, password: str):
+    user = next(i for i in users if i.username == username)
+    print(user)
+    if not user:
+        return False
+    if not verify_password(password, user.password_hash):
+        return False
+    return user
+
+
+def signJWT(user_id: str) -> Dict[str, str]:
+    payload = {"user_id": user_id, "expires": time.time() + 600}
+    token = jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+    return token
+
+
+def decodeJWT(token: str) -> dict:
+    try:
+        decoded_token = jwt.decode(
+            token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM]
+        )
+        return decoded_token if decoded_token["expires"] >= time.time() else None
+    except:
+        return {}
+
+
+class JWTBearer(HTTPBearer):
+    def __init__(self, auto_error: bool = True):
+        super(JWTBearer, self).__init__(auto_error=auto_error)
+
+    async def __call__(self, request: Request):
+        credentials: HTTPAuthorizationCredentials = await super(
+            JWTBearer, self
+        ).__call__(request)
+        if credentials:
+            if not credentials.scheme == "Bearer":
+                raise HTTPException(
+                    status_code=403, detail="Invalid authentication scheme."
+                )
+            if not self.verify_jwt(credentials.credentials):
+                raise HTTPException(
+                    status_code=403, detail="Invalid token or expired token."
+                )
+            return credentials.credentials
+        else:
+            raise HTTPException(status_code=403, detail="Invalid authorization code.")
+
+    def verify_jwt(self, jwtoken: str) -> bool:
+        isTokenValid: bool = False
+
+        try:
+            payload = decodeJWT(jwtoken)
+        except:
+            payload = None
+        if payload:
+            isTokenValid = True
+        return isTokenValid

--- a/core/security.py
+++ b/core/security.py
@@ -1,17 +1,18 @@
 from jose import jwt
 from passlib.context import CryptContext
-from fastapi.security import OAuth2PasswordBearer
-from fastapi import HTTPException
+from fastapi.security import OAuth2PasswordBearer, HTTPBearer, HTTPAuthorizationCredentials
+from fastapi import HTTPException, Request
 from core.config import settings
 from typing import Dict
 import time
-from fastapi import Request, HTTPException
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
 
 def verify_password(plain_password, hashed_password):
     return pwd_context.verify(plain_password, hashed_password)
@@ -19,10 +20,9 @@ def verify_password(plain_password, hashed_password):
 
 def authenticate_user(users, username: str, password: str):
     user = next(i for i in users if i.username == username)
-    print(user)
     if not user:
         return False
-    if not verify_password(password, user.password_hash):
+    if not verify_password(password, user.password):
         return False
     return user
 
@@ -30,7 +30,6 @@ def authenticate_user(users, username: str, password: str):
 def signJWT(user_id: str) -> Dict[str, str]:
     payload = {"user_id": user_id, "expires": time.time() + 600}
     token = jwt.encode(payload, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
-
     return token
 
 

--- a/core/security.py
+++ b/core/security.py
@@ -1,6 +1,10 @@
 from jose import jwt
 from passlib.context import CryptContext
-from fastapi.security import OAuth2PasswordBearer, HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import (
+    OAuth2PasswordBearer,
+    HTTPBearer,
+    HTTPAuthorizationCredentials,
+)
 from fastapi import HTTPException, Request
 from core.config import settings
 from typing import Dict
@@ -13,6 +17,7 @@ oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
 
 def get_password_hash(password):
     return pwd_context.hash(password)
+
 
 def verify_password(plain_password, hashed_password):
     return pwd_context.verify(plain_password, hashed_password)

--- a/db/mongodb.py
+++ b/db/mongodb.py
@@ -29,9 +29,9 @@ class MongoManager(DatabaseManager):
         return users_list
     
     async def get_user_by_username(self, username) -> UserSchema:
-        res = await self.db.users.find({"username" : username}).to_list(None)
-        user = res[0]
-        return UserSchema(**user, id=user["_id"])
+        user = await self.db.users.find_one({"username" : username})
+        print(username)
+        return UserSchema(**user, id=user["_id"]) if user else None
 
     async def create_user(self, user_info):
         await self.db.users.insert_one(user_info)

--- a/db/mongodb.py
+++ b/db/mongodb.py
@@ -27,3 +27,11 @@ class MongoManager(DatabaseManager):
         async for user in self.db.users.find():
             users_list.append(UserSchema(**user, id=user["_id"]))
         return users_list
+    
+    async def get_user_by_username(self, username) -> UserSchema:
+        res = await self.db.users.find({"username" : username}).to_list(None)
+        user = res[0]
+        return UserSchema(**user, id=user["_id"])
+
+    async def create_user(self, user_info):
+        await self.db.users.insert_one(user_info)

--- a/db/mongodb.py
+++ b/db/mongodb.py
@@ -2,7 +2,7 @@ from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
 from core.config import settings
 from db.db_manager_base import DatabaseManager
 from typing import List
-from schemas.users_schema import UserSchema
+from schemas.users_schema import UserSchema, Token
 
 
 class MongoManager(DatabaseManager):

--- a/db/mongodb.py
+++ b/db/mongodb.py
@@ -27,9 +27,9 @@ class MongoManager(DatabaseManager):
         async for user in self.db.users.find():
             users_list.append(UserSchema(**user, id=user["_id"]))
         return users_list
-    
+
     async def get_user_by_username(self, username) -> UserSchema:
-        user = await self.db.users.find_one({"username" : username})
+        user = await self.db.users.find_one({"username": username})
         print(username)
         return UserSchema(**user, id=user["_id"]) if user else None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 fastapi
 uvicorn
 motor
+python-jose
+passlib
+python-multipart

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ motor
 python-jose
 passlib
 python-multipart
+pymongo[srv]

--- a/schemas/users_schema.py
+++ b/schemas/users_schema.py
@@ -4,8 +4,13 @@ from typing import Optional
 
 class UserSchema(BaseDBModel):
     id: Optional[OID]
+    password_hash: str
     username: str
+    full_name: str
     city: str
 
 
-# add your model schemas here. Schema is used for validation.
+class Token(BaseDBModel):
+    id: Optional[OID]
+    access_token: str
+    token_type: str

--- a/schemas/users_schema.py
+++ b/schemas/users_schema.py
@@ -1,16 +1,16 @@
 from schemas.base_schema import BaseDBModel, OID
 from typing import Optional
 
-
-class UserSchema(BaseDBModel):
-    id: Optional[OID]
-    password_hash: str
+class UserBaseSchema(BaseDBModel):
+    password: str
     username: str
-    full_name: str
+    fullName: str
     city: str
 
+class UserSchema(UserBaseSchema):
+    id: Optional[OID]
 
 class Token(BaseDBModel):
     id: Optional[OID]
-    access_token: str
-    token_type: str
+    accessToken: str
+    tokenType: str

--- a/schemas/users_schema.py
+++ b/schemas/users_schema.py
@@ -1,14 +1,17 @@
 from schemas.base_schema import BaseDBModel, OID
 from typing import Optional
 
+
 class UserBaseSchema(BaseDBModel):
     password: str
     username: str
     fullName: str
     city: str
 
+
 class UserSchema(UserBaseSchema):
     id: Optional[OID]
+
 
 class Token(BaseDBModel):
     id: Optional[OID]


### PR DESCRIPTION
What's new?

1. Signup and login mechanism are implemented.
2. JWT authentification
3. Securing endpoints with an access token. 

In order to use API you need to add Bearer token to your request. In order to receive it you need to login into API (`api/v1/users/login endpoint`) or register (`api/v1/users/signup). Both methods will return the token like this:
```
{
  "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWRtaW4iLCJleHBpcmVzIjoxNjUxMzQ1NzQzLjgwNjI4NjZ9.SLEImBAL5pynWVEEMsZMJnGnEyD7cXXnpSIffm3MzKU",
  "token_type": "bearer"
}
```
Also, all passwords are hashed and stored in db in the following way:
```
{
  "_id": {
    "$oid": "626d84cf189c75781910d58c"
  },
  "password": "$2b$12$32zFBwKdn13CS8HOcu9Q4.dYta6FHGF3kmaPsz9OTODgvvVAM39Cm",
  "username": "admin",
  "fullName": "oleh andrus",
  "city": "Lviv"
}
```